### PR TITLE
Added an `exec` command. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+COPY builds/linux/secure-environment /usr/sbin/secure-environment
+ENTRYPOINT ["/usr/sbin/secure-environment", "exec", "--"]
+CMD env

--- a/README.md
+++ b/README.md
@@ -4,27 +4,26 @@ Forked from [virtru/secure-environment](https://github.com/virtru/secure-environ
 
 ## Introduction
 
-This tool is intended to be used on the start up of a Docker container to securely fetch and decrypt environment variables stored in S3 and encrypted with a KMS key. The included `secure-entrypoint.sh` script can be used along with the `secure-environment` binary.
+This tool is intended to be used on the start up of a Docker container to securely fetch and decrypt environment variables stored in S3 and encrypted with a KMS key.
 
 ### How it works
 
-The `docker-entrypoint.sh` script acts as an entrypoint for the Docker container. The script then calls the `secure-environment` binary to write a sourceable shell script to stdout that contains `export`ed environment variables.
+The `secure-environment exec` command acts as an entrypoint for the Docker container including the decrypted variables in the command environment.
 
 ### Setting up the Docker container
 
-To use this with Convox, you need to set the label `convox.environment.secure=true` to true on the services you intend to secure. 
+To use this with Convox, you need to set the label `convox.environment.secure=true` to true on the services you intend to secure.
 
-On your Docker container the `secure-entrypoint.sh` in the scripts folder of this repository and the latest Linux binary of the `secure-environment` executable should be copied into your Docker image at the following locations:
+On your Docker container the latest Linux binary of the `secure-environment` executable should be copied into your Docker image at the following locations:
 
 ```
-secure-environment -> /usr/sbin/secure-environment
-secure-entrypoint -> /usr/sbin/secure-entrypoint.sh
+COPY secure-environment /usr/sbin/secure-environment
 ```
 
 Finally, you need to set the `ENTRYPOINT` on your Dockerfile to this:
 
 ```
-ENTRYPOINT ["/usr/sbin/secure-entrypoint.sh"]
+ENTRYPOINT ["/usr/sbin/secure-environment", "exec", "--"]
 ```
 
 See [https://github.com/convox-examples/secure-env-example](https://github.com/convox-examples/secure-env-example) for example usage.

--- a/main.go
+++ b/main.go
@@ -142,8 +142,8 @@ func exportEnv(c *cli.Context) error {
 	secureEnvironmentURL := c.String("url")
 	secureEnvironmentKey := c.String("key")
 
-	env := os.Environ() // key='value'
-	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env)
+	env := os.Environ()
+	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env, true)
 	if err != nil {
 		return err
 	}
@@ -159,8 +159,8 @@ func execEnv(c *cli.Context) error {
 	secureEnvironmentURL := c.String("url")
 	secureEnvironmentKey := c.String("key")
 
-	env := os.Environ() // key='value'
-	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env)
+	env := os.Environ()
+	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env, false)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
+	"os/exec"
+	"os/signal"
+	"syscall"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -84,6 +86,12 @@ func main() {
 			Action: importEnv,
 			Flags:  flags,
 		},
+		{
+			Name:   "exec",
+			Usage:  "Run a command with decrypted env",
+			Action: execEnv,
+			Flags:  flags,
+		},
 	}
 
 	app.Run(os.Args)
@@ -133,66 +141,57 @@ func importEnv(c *cli.Context) error {
 func exportEnv(c *cli.Context) error {
 	secureEnvironmentURL := c.String("url")
 	secureEnvironmentKey := c.String("key")
-	secureEnvironmentType := c.String("env-type")
 
-	if secureEnvironmentURL == "" || secureEnvironmentKey == "" || secureEnvironmentType == "" {
-		log.Debug("Not configured to load secrets")
-		// Intentionally do not fail. This is not required software to run. It needs to fail silent if it's not configured on an export.
-		return nil
-	}
-
-	log.WithFields(log.Fields{
-		"secureEnvironmentURL": secureEnvironmentURL,
-	}).Debug("Attempting to load secure environment")
-
-	if secureEnvironmentKey == "" {
-		log.Debug("Cannot load secrets. No SECURE_ENVIRONMENT_KEY set")
-		os.Exit(1)
-		return nil
-	}
-
-	data, err := s3GetObject(secureEnvironmentURL)
+	env := []string{} // key='value'
+	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env)
 	if err != nil {
 		return err
 	}
 
-	log.Debug("Connecting to KMS")
-	cipher, err := NewCipher()
-	if err != nil {
-		return nil
+	for _, line := range env {
+		fmt.Printf("export %s\n", line)
 	}
 
-	// Decrypt
-	decryptedBytes, err := cipher.Decrypt(secureEnvironmentKey, data)
+	return nil
+}
+
+func execEnv(c *cli.Context) error {
+	secureEnvironmentURL := c.String("url")
+	secureEnvironmentKey := c.String("key")
+
+	env := []string{} // key='value'
+	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env)
 	if err != nil {
 		return err
 	}
 
-	// Process file and export the variables
-	decrypted := string(decryptedBytes)
+	args := c.Args()
+	ecmd := exec.Command(args.First(), args.Tail()...)
+	ecmd.Stdin = os.Stdin
+	ecmd.Stdout = os.Stdout
+	ecmd.Stderr = os.Stderr
+	ecmd.Env = env
 
-	decryptedLines := strings.Split(decrypted, "\n")
+	// Forward SIGINT, SIGTERM, SIGKILL to the child command
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
 
-	for lineNumber, line := range decryptedLines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			log.Debugf("Empty line: %d", lineNumber)
-			continue
+	go func() {
+		sig := <-sigChan
+		if ecmd.Process != nil {
+			ecmd.Process.Signal(sig)
 		}
-		if !envFileLineRegex.MatchString(line) {
-			log.Debugf("Invalid line: %d: %s", lineNumber, line)
-			continue
-		}
-		if line[0] == '#' {
-			log.Debug("Comment line found")
-			continue
-		}
-		splitLine := strings.Split(line, "=")
-		key := splitLine[0]
-		value := strings.Join(splitLine[1:], "=")
+	}()
 
-		fmt.Printf("export %s='%s'\n", key, escapeSingleQuote(value))
+	var waitStatus syscall.WaitStatus
+	if err := ecmd.Run(); err != nil {
+		if err != nil {
+			return err
+		}
+		if exitError, ok := err.(*exec.ExitError); ok {
+			waitStatus = exitError.Sys().(syscall.WaitStatus)
+			os.Exit(waitStatus.ExitStatus())
+		}
 	}
-
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func exportEnv(c *cli.Context) error {
 	secureEnvironmentURL := c.String("url")
 	secureEnvironmentKey := c.String("key")
 
-	env := []string{} // key='value'
+	env := os.Environ() // key='value'
 	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func execEnv(c *cli.Context) error {
 	secureEnvironmentURL := c.String("url")
 	secureEnvironmentKey := c.String("key")
 
-	env := []string{} // key='value'
+	env := os.Environ() // key='value'
 	err := decryptEnv(secureEnvironmentURL, secureEnvironmentKey, &env)
 	if err != nil {
 		return err

--- a/utils.go
+++ b/utils.go
@@ -137,7 +137,7 @@ func escapeSingleQuote(s string) string {
 	return strings.Replace(s, "'", "'\"'\"'", -1)
 }
 
-func decryptEnv(url, key string, env *[]string) error {
+func decryptEnv(url, key string, env *[]string, escape bool) error {
 	if url == "" || key == "" {
 		log.Debug("Not configured to load secrets")
 		// Intentionally do not fail. This is not required software to run. It needs to fail silent if it's not configured on an export.
@@ -193,7 +193,10 @@ func decryptEnv(url, key string, env *[]string) error {
 		splitLine := strings.Split(line, "=")
 		key := splitLine[0]
 		value := strings.Join(splitLine[1:], "=")
-		*env = append(*env, fmt.Sprintf("%s='%s'", key, escapeSingleQuote(value)))
+		if escape {
+			value = "'" + escapeSingleQuote(value) + "'"
+		}
+		*env = append(*env, fmt.Sprintf("%s=%s", key, value))
 	}
 
 	return nil


### PR DESCRIPTION
I had some issues using `secure-entrypoint.sh` as ENTRYPOINT in an alpine docker environment so I took the liberty of porting the exec command from [github.com/segmentio/chamber](https://github.com/segmentio/chamber). 

In short this means that `secure-environment` is now a fully self-contained binary and to use it in Docker you could simply add this (although direct curling might not be a good default so the docs still just mention the COPY command):

```
RUN curl https://github.com/convox/secure-environment/releases/download/v0.0.1/secure-environment > /usr/sbin/secure-environment && chmod +x /usr/sbin/secure-environment
ENTRYPOINT ["/usr/sbin/secure-environment", "exec", "--"]
```



